### PR TITLE
Refactor: Centralize Page Metadata and Persist Sidebar State

### DIFF
--- a/.agent/todos/todo.md
+++ b/.agent/todos/todo.md
@@ -1,0 +1,22 @@
+- [] radio & checkbox to use modern style. Rounded, minimalist border, there's fade animation, and box shadow on hover.
+- [] create stepper component
+- [] toggle/switch component
+- [] create box icon component
+- [] create table component (data table and default table)
+- [] create pagination component
+- [] create pop up search box component like command pallete. Add shortcut ctrl + k to search
+
+### inputs
+- [] filled input
+- [] autocomplete
+
+### Extra UI
+- [] login page
+- [] dashboard layout page
+
+
+### Other todo
+- [] the github ci pipeline still not working. Need to configure the husky
+
+
+reference : https://akveo.github.io/nebular/docs/components/toggle/overview#nbtogglecomponent

--- a/src/app/design-system/accordion/page.tsx
+++ b/src/app/design-system/accordion/page.tsx
@@ -8,19 +8,6 @@ export default function AccordionPage() {
   return (
     <Container sx={{ p: 4 }} maxWidth="xl">
       <Stack spacing={4}>
-        {/* Page Header */}
-        <Stack spacing={1}>
-          <Typography variant="h4" fontWeight={700} gutterBottom>
-            Accordion
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            Accordions contain creation flows and allow lightweight editing of
-            an element.
-          </Typography>
-        </Stack>
-
-        <Divider />
-
         {/* Basic */}
         <Stack spacing={2}>
           <Typography variant="h6" fontWeight={600}>

--- a/src/app/design-system/alert/page.tsx
+++ b/src/app/design-system/alert/page.tsx
@@ -9,19 +9,6 @@ export default function AlertPage() {
   return (
     <Container sx={{ p: 4 }} maxWidth="xl">
       <Stack spacing={4}>
-        {/* Page Header */}
-        <Stack spacing={1}>
-          <Typography variant="h4" fontWeight={700} gutterBottom>
-            Alert
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            Alerts display a short, important message in a way that attracts the
-            user's attention without interrupting the user's task.
-          </Typography>
-        </Stack>
-
-        <Divider />
-
         {/* Severity */}
         <Stack spacing={2}>
           <Typography variant="h6" fontWeight={600}>

--- a/src/app/design-system/avatar/page.tsx
+++ b/src/app/design-system/avatar/page.tsx
@@ -10,19 +10,6 @@ export default function AvatarPage() {
   return (
     <Container sx={{ p: 4 }} maxWidth="xl">
       <Stack spacing={4}>
-        {/* Page Header */}
-        <Stack spacing={1}>
-          <Typography variant="h4" fontWeight={700} gutterBottom>
-            Avatar
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            Avatars are found throughout material design with uses in everything
-            from tables to dialog menus.
-          </Typography>
-        </Stack>
-
-        <Divider />
-
         {/* Image Avatars */}
         <Stack spacing={2}>
           <Typography variant="h6" fontWeight={600}>

--- a/src/app/design-system/badge/page.tsx
+++ b/src/app/design-system/badge/page.tsx
@@ -5,18 +5,6 @@ export default function BadgePage() {
   return (
     <Container sx={{ p: 4 }} maxWidth="xl">
       <Stack spacing={4}>
-        {/* Page Header */}
-        <Stack spacing={1}>
-          <Typography variant="h4" fontWeight={700} gutterBottom>
-            Badge
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            Badge generates a small badge to the top-right of its child(ren).
-          </Typography>
-        </Stack>
-
-        <Divider />
-
         {/* Basic */}
         <Stack spacing={2}>
           <Typography variant="h6" fontWeight={600}>

--- a/src/app/design-system/breadcrumb/page.tsx
+++ b/src/app/design-system/breadcrumb/page.tsx
@@ -9,19 +9,6 @@ export default function BreadcrumbPage() {
   return (
     <Container sx={{ p: 4 }} maxWidth="xl">
       <Stack spacing={4}>
-        {/* Page Header */}
-        <Stack spacing={1}>
-          <Typography variant="h4" fontWeight={700} gutterBottom>
-            Breadcrumbs
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            Breadcrumbs allow users to inspect their current location within the
-            system hierarchy.
-          </Typography>
-        </Stack>
-
-        <Divider />
-
         {/* Basic */}
         <Stack spacing={2}>
           <Typography variant="h6" fontWeight={600}>

--- a/src/app/design-system/button/page.tsx
+++ b/src/app/design-system/button/page.tsx
@@ -12,20 +12,6 @@ export default function ButtonPage() {
   return (
     <Container sx={{ p: 4 }} maxWidth="xl">
       <Stack spacing={4}>
-        {/* Page Header */}
-        <Stack spacing={1}>
-          <Typography variant="h4" fontWeight={700} gutterBottom>
-            Button
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            Buttons allow users to take actions, and make choices, with a single
-            tap. Material UI buttons are used to communicate actions that users
-            can take.
-          </Typography>
-        </Stack>
-
-        <Divider />
-
         {/* Variants */}
         <Stack spacing={2}>
           <Typography variant="h6" fontWeight={600}>

--- a/src/app/design-system/calendar/page.tsx
+++ b/src/app/design-system/calendar/page.tsx
@@ -1,28 +1,19 @@
 import { Container, Divider, Stack, Typography } from "@mui/material";
-import { CalendarBasicDemo, CalendarViewDemo } from "@/ui/design-system/calendar";
+import {
+  CalendarBasicDemo,
+  CalendarViewDemo,
+} from "@/ui/design-system/calendar";
 
 export default function CalendarPage() {
   return (
     <Container sx={{ p: 4 }} maxWidth="xl">
       <Stack spacing={4}>
-        {/* Page Header */}
-        <Stack spacing={1}>
-          <Typography variant="h4" fontWeight={700} gutterBottom>
-            Calendar
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            Full-featured calendar component powered by FullCalendar.
-          </Typography>
-        </Stack>
-
-        <Divider />
-
         {/* Basic Calendar */}
         <Stack spacing={2}>
           <Typography variant="h6" fontWeight={600}>
             Basic Month View
           </Typography>
-           <Typography variant="body2" color="text.secondary">
+          <Typography variant="body2" color="text.secondary">
             Displays events in a standard monthly grid.
           </Typography>
           <CalendarBasicDemo />
@@ -35,12 +26,11 @@ export default function CalendarPage() {
           <Typography variant="h6" fontWeight={600}>
             Agenda & Time Grid
           </Typography>
-           <Typography variant="body2" color="text.secondary">
+          <Typography variant="body2" color="text.secondary">
             Switch between Month, Week, and Day views with time slots.
           </Typography>
           <CalendarViewDemo />
         </Stack>
-
       </Stack>
     </Container>
   );

--- a/src/app/design-system/card/page.tsx
+++ b/src/app/design-system/card/page.tsx
@@ -10,18 +10,6 @@ export default function CardPage() {
   return (
     <Container sx={{ p: 4 }} maxWidth="xl">
       <Stack spacing={4}>
-        {/* Page Header */}
-        <Stack spacing={1}>
-          <Typography variant="h4" fontWeight={700} gutterBottom>
-            Card
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            Cards contain content and actions about a single subject.
-          </Typography>
-        </Stack>
-
-        <Divider />
-
         {/* Basic */}
         <Stack spacing={2}>
           <Typography variant="h6" fontWeight={600}>

--- a/src/app/design-system/chart/page.tsx
+++ b/src/app/design-system/chart/page.tsx
@@ -10,18 +10,6 @@ export default function ChartPage() {
   return (
     <Container sx={{ p: 4 }} maxWidth="xl">
       <Stack spacing={4}>
-        {/* Page Header */}
-        <Stack spacing={1}>
-          <Typography variant="h4" fontWeight={700} gutterBottom>
-            Charts
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            Visual representations of data using ApexCharts.
-          </Typography>
-        </Stack>
-
-        <Divider />
-
         <Grid container spacing={4}>
           {/* Line Chart */}
           <Grid size={{ xs: 12, lg: 6 }}>

--- a/src/app/design-system/checkbox/page.tsx
+++ b/src/app/design-system/checkbox/page.tsx
@@ -10,18 +10,6 @@ export default function CheckboxPage() {
   return (
     <Container sx={{ p: 4 }} maxWidth="xl">
       <Stack spacing={4}>
-        {/* Page Header */}
-        <Stack spacing={1}>
-          <Typography variant="h4" fontWeight={700} gutterBottom>
-            Checkbox
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            Checkboxes allow the user to select one or more items from a set.
-          </Typography>
-        </Stack>
-
-        <Divider />
-
         {/* Basic */}
         <Stack spacing={2}>
           <Typography variant="h6" fontWeight={600}>

--- a/src/app/design-system/chip/page.tsx
+++ b/src/app/design-system/chip/page.tsx
@@ -9,19 +9,6 @@ export default function ChipPage() {
   return (
     <Container sx={{ p: 4 }} maxWidth="xl">
       <Stack spacing={4}>
-        {/* Page Header */}
-        <Stack spacing={1}>
-          <Typography variant="h4" fontWeight={700} gutterBottom>
-            Chip
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            Chips allow users to enter information, make selections, filter
-            content, or trigger actions.
-          </Typography>
-        </Stack>
-
-        <Divider />
-
         {/* Basic */}
         <Stack spacing={2}>
           <Typography variant="h6" fontWeight={600}>

--- a/src/app/design-system/color/page.tsx
+++ b/src/app/design-system/color/page.tsx
@@ -1,24 +1,10 @@
-import { Container, Divider, Stack, Typography } from "@mui/material";
+import { Container, Stack } from "@mui/material";
 import { ColorPaletteDemo } from "@/ui/design-system/color";
 
 export default function ColorPage() {
   return (
     <Container sx={{ p: 4 }} maxWidth="xl">
       <Stack spacing={4}>
-        {/* Page Header */}
-        <Stack spacing={1}>
-          <Typography variant="h4" fontWeight={700} gutterBottom>
-            Colors
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            The application uses a comprehensive color system with defined
-            palettes for consistency. Each color scale ranges from 25 to
-            900/950.
-          </Typography>
-        </Stack>
-
-        <Divider />
-
         {/* Color Palettes Section */}
         <ColorPaletteDemo />
       </Stack>

--- a/src/app/design-system/icon/page.tsx
+++ b/src/app/design-system/icon/page.tsx
@@ -1,4 +1,4 @@
-import { Container, Divider, Stack, Typography } from "@mui/material";
+import { Container, Divider, Stack } from "@mui/material";
 import {
   IconResources,
   MuiIconsDemo,
@@ -9,20 +9,6 @@ export default function IconPage() {
   return (
     <Container sx={{ p: 4 }} maxWidth="xl">
       <Stack spacing={4}>
-        {/* Page Header */}
-        <Stack spacing={1}>
-          <Typography variant="h4" fontWeight={700} gutterBottom>
-            Icons
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            The system supports two icon libraries: Material UI Icons for
-            standard system actions and Phosphor Icons for a more modern,
-            flexible aesthetic.
-          </Typography>
-        </Stack>
-
-        <Divider />
-
         {/* Resources Section */}
         <IconResources />
 

--- a/src/app/design-system/input/page.tsx
+++ b/src/app/design-system/input/page.tsx
@@ -10,19 +10,6 @@ export default function InputPage() {
   return (
     <Container sx={{ p: 4 }} maxWidth="xl">
       <Stack spacing={4}>
-        {/* Page Header */}
-        <Stack spacing={1}>
-          <Typography variant="h4" fontWeight={700} gutterBottom>
-            Input
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            Text fields allow users to enter text into a UI. They typically
-            appear in forms and dialogs.
-          </Typography>
-        </Stack>
-
-        <Divider />
-
         {/* Variants */}
         <Stack spacing={2}>
           <Typography variant="h6" fontWeight={600}>

--- a/src/app/design-system/map/page.tsx
+++ b/src/app/design-system/map/page.tsx
@@ -5,25 +5,14 @@ export default function MapPage() {
   return (
     <Container sx={{ p: 4 }} maxWidth="xl">
       <Stack spacing={4}>
-        {/* Page Header */}
-        <Stack spacing={1}>
-          <Typography variant="h4" fontWeight={700} gutterBottom>
-            Maps
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            Visualize geographical data using SVG-based maps.
-          </Typography>
-        </Stack>
-
-        <Divider />
-
         {/* World Map */}
         <Stack spacing={2}>
           <Typography variant="h6" fontWeight={600}>
             World Map
           </Typography>
-           <Typography variant="body2" color="text.secondary">
-            A simple world map visualization using <code>react-simple-maps</code>.
+          <Typography variant="body2" color="text.secondary">
+            A simple world map visualization using{" "}
+            <code>react-simple-maps</code>.
           </Typography>
           <MapWorldDemo />
         </Stack>

--- a/src/app/design-system/modal/page.tsx
+++ b/src/app/design-system/modal/page.tsx
@@ -9,18 +9,6 @@ export default function ModalPage() {
   return (
     <Container sx={{ p: 4 }} maxWidth="xl">
       <Stack spacing={4}>
-        {/* Page Header */}
-        <Stack spacing={1}>
-          <Typography variant="h4" fontWeight={700} gutterBottom>
-            Modal
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            Modals provide critical information or ask for decisions.
-          </Typography>
-        </Stack>
-
-        <Divider />
-
         {/* Basic (Custom Layout) */}
         <Stack spacing={2}>
           <Typography variant="h6" fontWeight={600}>

--- a/src/app/design-system/radio/page.tsx
+++ b/src/app/design-system/radio/page.tsx
@@ -9,18 +9,6 @@ export default function RadioPage() {
   return (
     <Container sx={{ p: 4 }} maxWidth="xl">
       <Stack spacing={4}>
-        {/* Page Header */}
-        <Stack spacing={1}>
-          <Typography variant="h4" fontWeight={700} gutterBottom>
-            Radio Button
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            Radio buttons allow the user to select one option from a set.
-          </Typography>
-        </Stack>
-
-        <Divider />
-
         {/* Basic */}
         <Stack spacing={2}>
           <Typography variant="h6" fontWeight={600}>
@@ -38,8 +26,6 @@ export default function RadioPage() {
           </Typography>
           <RadioColorsDemo />
         </Stack>
-
-        <Divider />
 
         {/* Sizes */}
         <Stack spacing={2}>

--- a/src/app/design-system/rich-text-editor/page.tsx
+++ b/src/app/design-system/rich-text-editor/page.tsx
@@ -6,19 +6,6 @@ export default function RichTextEditorPage() {
   return (
     <Container sx={{ p: 4 }} maxWidth="xl">
       <Stack spacing={4}>
-        {/* Page Header */}
-        <Stack spacing={1}>
-          <Typography variant="h4" fontWeight={700} gutterBottom>
-            Rich Text Editor
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            A headless, framework-agnostic text editor framework for the web
-            (Tiptap).
-          </Typography>
-        </Stack>
-
-        <Divider />
-
         {/* Basic Editor */}
         <Stack spacing={2}>
           <Typography variant="h6" fontWeight={600}>

--- a/src/app/design-system/select/page.tsx
+++ b/src/app/design-system/select/page.tsx
@@ -9,19 +9,6 @@ export default function SelectPage() {
   return (
     <Container sx={{ p: 4 }} maxWidth="xl">
       <Stack spacing={4}>
-        {/* Page Header */}
-        <Stack spacing={1}>
-          <Typography variant="h4" fontWeight={700} gutterBottom>
-            Select & Autocomplete
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            Select components allow users to choose one or multiple items from a
-            list.
-          </Typography>
-        </Stack>
-
-        <Divider />
-
         {/* Basic Select */}
         <Stack spacing={2}>
           <Typography variant="h6" fontWeight={600}>

--- a/src/app/design-system/shadow/page.tsx
+++ b/src/app/design-system/shadow/page.tsx
@@ -1,4 +1,4 @@
-import { Container, Divider, Stack, Typography } from "@mui/material";
+import { Container, Divider, Stack } from "@mui/material";
 import {
   ShadowComparisonDemo,
   ShadowScaleDemo,
@@ -9,20 +9,6 @@ export default function ShadowPage() {
   return (
     <Container sx={{ p: 4 }} maxWidth="xl">
       <Stack spacing={4}>
-        {/* Page Header */}
-        <Stack spacing={1}>
-          <Typography variant="h4" fontWeight={700} gutterBottom>
-            Shadows
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            Documentation and examples for the shadow system. Provides 7
-            elevation levels using consistent dark gray tints for depth and
-            hierarchy.
-          </Typography>
-        </Stack>
-
-        <Divider />
-
         {/* Shadow Comparison */}
         <ShadowComparisonDemo />
 

--- a/src/app/design-system/slider/page.tsx
+++ b/src/app/design-system/slider/page.tsx
@@ -1,22 +1,15 @@
 import { Container, Divider, Stack, Typography } from "@mui/material";
-import { SliderAutoplayDemo, SliderBannerDemo, SliderBasicDemo, SliderProductDemo } from "@/ui/design-system/slider";
+import {
+  SliderAutoplayDemo,
+  SliderBannerDemo,
+  SliderBasicDemo,
+  SliderProductDemo,
+} from "@/ui/design-system/slider";
 
 export default function SliderPage() {
   return (
     <Container sx={{ p: 4 }} maxWidth="xl">
       <Stack spacing={4}>
-        {/* Page Header */}
-        <Stack spacing={1}>
-          <Typography variant="h4" fontWeight={700} gutterBottom>
-            Sliders
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            Carousels allow users to cycle through a series of content. Powered by Embla Carousel.
-          </Typography>
-        </Stack>
-
-        <Divider />
-
         {/* Basic Slider */}
         <Stack spacing={2}>
           <Typography variant="h6" fontWeight={600}>

--- a/src/app/design-system/snackbar/page.tsx
+++ b/src/app/design-system/snackbar/page.tsx
@@ -8,19 +8,6 @@ export default function SnackbarPage() {
   return (
     <Container sx={{ p: 4 }} maxWidth="xl">
       <Stack spacing={4}>
-        {/* Page Header */}
-        <Stack spacing={1}>
-          <Typography variant="h4" fontWeight={700} gutterBottom>
-            Snackbar
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            Snackbars provide brief messages about app processes. The component
-            is also known as a toast.
-          </Typography>
-        </Stack>
-
-        <Divider />
-
         {/* Basic */}
         <Stack spacing={2}>
           <Typography variant="h6" fontWeight={600}>

--- a/src/app/design-system/spacing/page.tsx
+++ b/src/app/design-system/spacing/page.tsx
@@ -5,20 +5,6 @@ export default function SpacingPage() {
   return (
     <Container sx={{ p: 4 }} maxWidth="xl">
       <Stack spacing={4}>
-        {/* Page Header */}
-        <Stack spacing={1}>
-          <Typography variant="h4" fontWeight={700} gutterBottom>
-            Spacing
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            The design system uses a consistent spacing scale to ensure visual
-            rhythm and balance. Values are defined in pixels but often converted
-            to rem.
-          </Typography>
-        </Stack>
-
-        <Divider />
-
         {/* Usage Demo */}
         <SpacingUsageDemo />
 

--- a/src/app/design-system/tabs/page.tsx
+++ b/src/app/design-system/tabs/page.tsx
@@ -9,18 +9,6 @@ export default function TabsPage() {
   return (
     <Container sx={{ p: 4 }} maxWidth="xl">
       <Stack spacing={4}>
-        {/* Page Header */}
-        <Stack spacing={1}>
-          <Typography variant="h4" fontWeight={700} gutterBottom>
-            Tabs
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            Tabs make it easy to explore and switch between different views.
-          </Typography>
-        </Stack>
-
-        <Divider />
-
         {/* Basic */}
         <Stack spacing={2}>
           <Typography variant="h6" fontWeight={600}>

--- a/src/app/design-system/tooltip/page.tsx
+++ b/src/app/design-system/tooltip/page.tsx
@@ -8,19 +8,6 @@ export default function TooltipPage() {
   return (
     <Container sx={{ p: 4 }} maxWidth="xl">
       <Stack spacing={4}>
-        {/* Page Header */}
-        <Stack spacing={1}>
-          <Typography variant="h4" fontWeight={700} gutterBottom>
-            Tooltip
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            Tooltips display informative text when users hover over, focus on,
-            or tap an element.
-          </Typography>
-        </Stack>
-
-        <Divider />
-
         {/* Positions */}
         <Stack spacing={2}>
           <Typography variant="h6" fontWeight={600}>

--- a/src/app/design-system/typography/page.tsx
+++ b/src/app/design-system/typography/page.tsx
@@ -1,4 +1,4 @@
-import { Box, Container, Divider, Stack, Typography } from "@mui/material";
+import { Container, Divider, Stack } from "@mui/material";
 import {
   FontWeightDemo,
   TypographyPropsTable,
@@ -9,20 +9,6 @@ export default function TypographyPage() {
   return (
     <Container sx={{ p: 4 }} maxWidth="xl">
       <Stack spacing={4}>
-        {/* Page Header */}
-        <Box>
-          <Typography variant="h4" fontWeight={700} gutterBottom>
-            Typography
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            Documentation and examples for the typography system. Built on top
-            of Material UI Typography with custom styling using the Inter font
-            family.
-          </Typography>
-        </Box>
-
-        <Divider />
-
         {/* Typography Scale Section */}
         <TypographyScaleDemo />
 

--- a/src/app/design-system/upload-file/page.tsx
+++ b/src/app/design-system/upload-file/page.tsx
@@ -11,18 +11,6 @@ export default function UploadFilePage() {
   return (
     <Container sx={{ p: 4 }} maxWidth="xl">
       <Stack spacing={4}>
-        {/* Page Header */}
-        <Stack spacing={1}>
-          <Typography variant="h4" fontWeight={700} gutterBottom>
-            Upload File
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            Various methods for uploading files, from simple buttons to complex picture walls.
-          </Typography>
-        </Stack>
-
-        <Divider />
-
         {/* Drag & Drop */}
         <Stack spacing={2}>
           <Typography variant="h6" fontWeight={600}>
@@ -58,7 +46,7 @@ export default function UploadFilePage() {
           <Typography variant="h6" fontWeight={600}>
             Picture Wall
           </Typography>
-           <Typography variant="body2" color="text.secondary">
+          <Typography variant="body2" color="text.secondary">
             Multiple image upload with preview and delete actions.
           </Typography>
           <UploadPictureWallDemo />
@@ -66,14 +54,13 @@ export default function UploadFilePage() {
 
         <Divider />
 
-         {/* Card Upload */}
-         <Stack spacing={2}>
+        {/* Card Upload */}
+        <Stack spacing={2}>
           <Typography variant="h6" fontWeight={600}>
             Card Upload
           </Typography>
           <UploadCardDemo />
         </Stack>
-
       </Stack>
     </Container>
   );

--- a/src/constant/dashboard-menu.tsx
+++ b/src/constant/dashboard-menu.tsx
@@ -56,30 +56,40 @@ export const listCustomization: MenuItem[] = [
   {
     menuKey: "typography",
     title: "Typography",
+    subtitle:
+      "Documentation and examples for the typography system. Built on top of Material UI Typography with custom styling using the Inter font family.",
     path: "/design-system/typography",
     icon: <TextT size={22} weight="bold" />,
   },
   {
     menuKey: "shadows",
     title: "Shadows",
+    subtitle:
+      "Documentation and examples for the shadow system. Provides 7 elevation levels using consistent dark gray tints for depth and hierarchy.",
     path: "/design-system/shadow",
     icon: <WaveSine size={22} weight="bold" />,
   },
   {
     menuKey: "colors",
     title: "Colors",
+    subtitle:
+      "The application uses a comprehensive color system with defined palettes for consistency. Each color scale ranges from 25 to 900/950.",
     path: "/design-system/color",
     icon: <Palette size={22} weight="bold" />,
   },
   {
     menuKey: "icons",
     title: "Icons",
+    subtitle:
+      "The system supports two icon libraries: Material UI Icons for standard system actions and Phosphor Icons for a more modern, flexible aesthetic.",
     path: "/design-system/icon",
     icon: <Smiley size={22} weight="bold" />,
   },
   {
     menuKey: "spacing",
     title: "Spacing",
+    subtitle:
+      "The design system uses a consistent spacing scale to ensure visual rhythm and balance. Values are defined in pixels but often converted to rem.",
     path: "/design-system/spacing",
     icon: <SquaresFour size={22} weight="bold" />,
   },
@@ -89,30 +99,39 @@ export const listMenuForms: MenuItem[] = [
   {
     menuKey: "inputs",
     title: "Inputs",
+    subtitle:
+      "Text fields allow users to enter text into a UI. They typically appear in forms and dialogs.",
     path: "/design-system/input",
     icon: <Textbox size={22} weight="bold" />,
   },
   {
     menuKey: "checkbox",
     title: "Checkbox",
+    subtitle:
+      "Checkboxes allow the user to select one or more items from a set.",
     path: "/design-system/checkbox",
     icon: <CheckCircle size={22} weight="bold" />,
   },
   {
     menuKey: "radio",
     title: "Radio",
+    subtitle: "Radio buttons allow the user to select one option from a set",
     path: "/design-system/radio",
     icon: <RadioButton size={22} weight="bold" />,
   },
   {
     menuKey: "select",
     title: "Select",
+    subtitle:
+      "Select components allow users to choose one or multiple items from a list.",
     path: "/design-system/select",
     icon: <Rows size={22} weight="bold" />,
   },
   {
     menuKey: "upload-file",
     title: "Upload File",
+    subtitle:
+      "Various methods for uploading files, from simple buttons to complex picture walls.",
     path: "/design-system/upload-file",
     icon: <CloudArrowUp size={22} weight="bold" />,
   },
@@ -122,42 +141,56 @@ export const listComponents: MenuItem[] = [
   {
     menuKey: "button",
     title: "Button",
+    subtitle:
+      "Buttons allow users to take actions, and make choices, with a single tap. Material UI buttons are used to communicate actions that users can take.",
     path: "/design-system/button",
     icon: <Rectangle size={22} weight="bold" />,
   },
   {
     menuKey: "badge",
     title: "Badge",
+    subtitle:
+      "Badge generates a small badge to the top-right of its child(ren).",
     path: "/design-system/badge",
     icon: <Pill size={22} weight="bold" />,
   },
   {
     menuKey: "chip",
     title: "Chip",
+    subtitle:
+      "Chips allow users to enter information, make selections, filter content, or trigger actions.",
     path: "/design-system/chip",
     icon: <Pill size={22} weight="bold" />, // Using Pill for Chip as well if no specific icon
   },
   {
     menuKey: "avatars",
     title: "Avatars",
+    subtitle:
+      "Avatars are found throughout material design with uses in everything from tables to dialog menus.",
     path: "/design-system/avatar",
     icon: <UserCircle size={22} weight="bold" />,
   },
   {
     menuKey: "tooltips",
     title: "Tooltips",
+    subtitle:
+      "Tooltips display informative text when users hover over, focus on, or tap an element.",
     path: "/design-system/tooltip",
     icon: <Info size={22} weight="bold" />,
   },
   {
     menuKey: "alert",
     title: "Alert",
+    subtitle:
+      "Alerts display a short, important message in a way that attracts the user's attention without interrupting the user's task.",
     path: "/design-system/alert",
     icon: <WarningCircle size={22} weight="bold" />,
   },
   {
     menuKey: "snackbar",
     title: "Snackbar",
+    subtitle:
+      "Snackbars provide brief messages about app processes. The component is also known as a toast.",
     path: "/design-system/snackbar",
     icon: <BellRinging size={22} weight="bold" />,
   },
@@ -168,32 +201,46 @@ export const listComponents: MenuItem[] = [
     icon: <Table size={22} weight="bold" />,
   },
   {
+    menuKey: "stepper",
+    title: "Stepper",
+    path: "/design-system/stepper",
+    icon: <Table size={22} weight="bold" />,
+  },
+  {
     menuKey: "accordion",
     title: "Accordion",
+    subtitle:
+      "Accordions contain creation flows and allow lightweight editing of an element.",
     path: "/design-system/accordion",
     icon: <Rows size={22} weight="bold" />,
   },
   {
     menuKey: "card",
     title: "Card",
+    subtitle: "Cards contain content and actions about a single subject.",
     path: "/design-system/card",
     icon: <Cards size={22} weight="bold" />,
   },
   {
     menuKey: "breadcrumbs",
     title: "Breadcrumbs",
+    subtitle:
+      "Breadcrumbs allow users to inspect their current location within the system hierarchy.",
     path: "/design-system/breadcrumb",
     icon: <Link size={22} weight="bold" />,
   },
   {
     menuKey: "tabs",
     title: "Tabs",
+    subtitle:
+      "Tabs make it easy to explore and switch between different views.",
     path: "/design-system/tabs",
     icon: <Tabs size={22} weight="bold" />,
   },
   {
     menuKey: "modal",
     title: "Modal",
+    subtitle: "Modals provide critical information or ask for decisions.",
     path: "/design-system/modal",
     icon: <StackSimple size={22} weight="bold" />,
   },
@@ -203,33 +250,42 @@ export const listExtraUI: MenuItem[] = [
   {
     menuKey: "rich-text-editor",
     title: "Rich Text Editor",
+    subtitle:
+      "A headless, framework-agnostic text editor framework for the web (Tiptap).",
     path: "/design-system/rich-text-editor",
     icon: <BracketsAngle size={22} weight="bold" />,
   },
   {
     menuKey: "chart",
     title: "Chart",
+    subtitle: "Visual representations of data using ApexCharts.",
     path: "/design-system/chart",
     icon: <ChartLineUp size={22} weight="bold" />,
   },
   {
     menuKey: "calendar",
     title: "Calendar",
+    subtitle: "Full-featured calendar component powered by FullCalendar.",
     path: "/design-system/calendar",
     icon: <Calendar size={22} weight="bold" />,
   },
   {
     menuKey: "sliders",
     title: "Sliders",
+    subtitle:
+      "Carousels allow users to cycle through a series of content. Powered by Embla Carousel.",
     path: "/design-system/slider",
     icon: <Sliders size={22} weight="bold" />,
   },
   {
     menuKey: "map",
     title: "Map",
+    subtitle: "Visualize geographical data using SVG-based maps.",
     path: "/design-system/map",
     icon: <MapTrifold size={22} weight="bold" />,
   },
 ];
+
+export const listPages: MenuItem[] = [];
 
 export default dashboardMenu;

--- a/src/providers/ThemeRegistry.tsx
+++ b/src/providers/ThemeRegistry.tsx
@@ -31,8 +31,9 @@ const ThemeProviderWrapper = ({ children }: { children: React.ReactNode }) => {
               z-index: 9999 !important;
             }
             .nprogress .bar {
+              transition: all 0.5s ease-in-out;
               z-index: 9999 !important;
-              background: var(--primary-300) !important;
+              background: var(--primary-500) !important;
               position: fixed;
               top: 0;
               left: 0;

--- a/src/theme/ts/components.ts
+++ b/src/theme/ts/components.ts
@@ -96,7 +96,6 @@ export const createComponents = (mode: "light" | "dark"): Components => {
       defaultProps: {
         variant: "contained",
         size: "md",
-        disableRipple: true,
       },
       styleOverrides: {
         root: {

--- a/src/ui/design-system/badge/BadgeVisibilityDemo.tsx
+++ b/src/ui/design-system/badge/BadgeVisibilityDemo.tsx
@@ -29,21 +29,23 @@ export default function BadgeVisibilityDemo() {
           </Badge>
           <Stack spacing={1} direction="row">
             <Button
+              data-shape="icon"
               aria-label="reduce"
               onClick={() => {
                 setCount(Math.max(count - 1, 0));
               }}
-              variant="outlined"
+              variant="text"
               size="sm"
             >
               -
             </Button>
             <Button
+              data-shape="icon"
               aria-label="increase"
               onClick={() => {
                 setCount(count + 1);
               }}
-              variant="outlined"
+              variant="text"
               size="sm"
             >
               +

--- a/src/ui/design-system/icon/MuiIconsDemo.tsx
+++ b/src/ui/design-system/icon/MuiIconsDemo.tsx
@@ -143,7 +143,7 @@ function IconCard({
         height: 100,
         transition: "all 0.2s",
         "&:hover": {
-          borderColor: "primary.main",
+          borderColor: "text.secondary",
           bgcolor: "action.hover",
           transform: "translateY(-2px)",
           boxShadow: shadows.lg,
@@ -189,7 +189,7 @@ export default function MuiIconsDemo() {
         </Typography>
         <Chip
           label="@mui/icons-material"
-          color="secondary"
+          color="primary"
           size="small"
           sx={{ fontFamily: "monospace" }}
         />

--- a/src/ui/design-system/icon/PhosphorIconsDemo.tsx
+++ b/src/ui/design-system/icon/PhosphorIconsDemo.tsx
@@ -163,7 +163,7 @@ function IconCard({
         height: 100,
         transition: "all 0.2s",
         "&:hover": {
-          borderColor: "primary.main",
+          borderColor: "text.secondary",
           bgcolor: "action.hover",
           transform: "translateY(-2px)",
           boxShadow: shadows.lg,
@@ -209,7 +209,7 @@ export default function PhosphorIconsDemo() {
         </Typography>
         <Chip
           label="phosphor-react"
-          color="primary"
+          color="warning"
           size="small"
           sx={{ fontFamily: "monospace" }}
         />

--- a/src/ui/layouts/Dashboard/DashboardLayout.tsx
+++ b/src/ui/layouts/Dashboard/DashboardLayout.tsx
@@ -21,13 +21,14 @@ import {
   SignOut,
   UserCircle,
 } from "phosphor-react";
-import React, { ReactNode, useState } from "react";
+import React, { ReactNode, useEffect, useState } from "react";
 import dashboardMenu, {
   MenuItem as DashboardMenuItem,
   listComponents,
   listCustomization,
   listExtraUI,
   listMenuForms,
+  listPages,
 } from "@/constant/dashboard-menu";
 import { getColors } from "@/theme/ts/colors";
 import { ThemeToggle } from "@/ui/components/ThemeToggle";
@@ -72,14 +73,33 @@ const MenuTitle: React.FC<{ title: string }> = ({ title }) => {
   );
 };
 
+// # constants
+const SIDEBAR_STORAGE_KEY = "dashboard_sidebar_visible";
+
+const allMenus = [
+  ...dashboardMenu,
+  ...listCustomization,
+  ...listMenuForms,
+  ...listComponents,
+  ...listExtraUI,
+];
+
 // DashboardLayout
 export default function DashboardLayout({ children }: DashboardLayoutProps) {
   const pathname = usePathname();
   const router = useRouter();
   const theme = useTheme();
   const colors = getColors(theme.palette.mode);
-  const menu = dashboardMenu.find((item) => pathname.includes(item.path));
-  const [showSidebar, setShowSidebar] = useState(false);
+  const menu = allMenus.find((item) => pathname.trim().includes(item.path));
+  const [showSidebar, setShowSidebar] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return sessionStorage.getItem(SIDEBAR_STORAGE_KEY) === "true";
+  });
+
+  // Sync sidebar state to sessionStorage
+  useEffect(() => {
+    sessionStorage.setItem(SIDEBAR_STORAGE_KEY, String(showSidebar));
+  }, [showSidebar]);
 
   const handleLogout = async () => {
     const result = await logout();
@@ -135,6 +155,8 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
           <MenuItems menus={listComponents} />
           <MenuTitle title="Extra UI" />
           <MenuItems menus={listExtraUI} />
+          <MenuTitle title="Pages" />
+          <MenuItems menus={listPages} />
         </MenuList>
         <Stack direction={"column"} className={classes.SidebarFooter}>
           <Button
@@ -176,8 +198,8 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
         >
           <Box>
             <Typography
-              variant="h6"
-              fontWeight={"semiBold"}
+              variant="h5"
+              fontWeight={"bold"}
               className={classes.PageTitle}
               mb={2}
             >


### PR DESCRIPTION
This PR centralizes page metadata (titles and subtitles) into the dashboard menu configuration and removes redundant headers from component pages. It also implements sidebar state persistence using sessionStorage.

### Key Changes:
- **Refactor**: Metadata (titles/subtitles) moved from pages to `src/constant/dashboard-menu.tsx`.
- **UI**: Removed redundant headers and dividers from 10+ design system pages.
- **UX**: Sidebar open/close state now persists across refreshes using `sessionStorage`.
- **Bug Fix**: Menu lookup logic in `DashboardLayout` now correctly finds items across all menu categories.